### PR TITLE
页面修改

### DIFF
--- a/wechat/app/views/changeps.html
+++ b/wechat/app/views/changeps.html
@@ -3,6 +3,26 @@ description 个人信息修改页面
 router:#!/changeps
  -->
 <div class="weui-cells weui-cells_form">
+    <div class="weui-cell">
+        <div class="weui-cell__bd">
+            <div class="weui-uploader">
+                <div class="weui-uploader__hd">
+                    <p class="weui-uploader__title">上传头像</p>
+                </div>
+                <div class="weui-uploader__bd">
+                    <div class="weui-uploader__input-box">
+                        <input id="uploaderInput" class="weui-uploader__input" type="file" accept="image/*" multiple />
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="weui-cell">
+        <div class="weui-cell__hd"><label class="weui-label">昵称</label></div>
+            <div class="weui-cell__bd">
+                <input class="weui-input" type="" pattern="" placeholder="请输入昵称"/>
+            </div>
+    </div>
     <div class="weui-cell weui-cell_vcode">
         <div class="weui-cell__hd">
             <label class="weui-label">绑定手机</label>
@@ -19,12 +39,92 @@ router:#!/changeps
             <label class="weui-label">邮箱</label>
         </div>
         <div class="weui-cell__bd">
-            <input class="weui-input" type="number" pattern="[0-9]*" placeholder="单行输入" />
+            <input class="weui-input" type="" pattern="" placeholder="单行输入" />
         </div>
     </div>
+    <div class="weui-cell">
+                <div class="weui-cell__hd"><label class="weui-label">性别</label></div>
+                <div class="weui-cell__bd">
+                <div class="weui-cell weui-cell_select weui-cell_select-before">
+                    <select class="weui-select" name="select1">
+                        <option value="1">男</option>
+                        <option value="2">女</option>
+                    </select>
+                </div>
+                </div>
+    </div>
+    <div class="weui-cell">
+                <div class="weui-cell__hd"><label for="" class="weui-label">出生日期</label></div>
+                <div class="weui-cell__bd">
+                    <input class="weui-input" type="date" value=""/>
+                </div>
+    </div>
+    <div class="weui-cell">
+        <div class="weui-cell__hd">
+            <label class="weui-label">所在城市</label>
+        </div>
+        <div class="weui-cell__bd">
+            <input class="weui-input" type="" pattern="" placeholder="" />
+        </div>
+    </div>
+    <div class="weui-cell">
+        <div class="weui-cell__hd"><label class="weui-label">绑定身份证</label></div>
+            <div class="weui-cell__bd">
+                <input class="weui-input" type="" pattern="" placeholder="请输入身份证号"/>
+            </div>
+    </div>
+    <div class="weui-cell">
+    <div class="weui-cell__bd">
+            <div class="weui-uploader">
+                <div class="weui-uploader__hd">
+                    <p class="weui-uploader__title">上传身份证正反面用于审核</p>
+                </div>
+                <div class="weui-uploader__bd">
+                    <div class="weui-uploader__input-box">
+                        <input id="uploaderInput" class="weui-uploader__input" type="file" accept="image/*" multiple />
+                    </div>
+                     <div class="weui-uploader__input-box">
+                        <input id="uploaderInput" class="weui-uploader__input" type="file" accept="image/*" multiple />
+                    </div>
+                </div>
+            </div>
+    </div>
+    </div>
 </div>
+
 <div class="page__bd page__bd_spacing">
-    <a ui-sref="personal" class="weui-btn weui-btn_primary" style="margin-right:20px;margin-left:20px;margin-top: 100px">
+    <a ui-sref="personal" class="weui-btn weui-btn_primary" style="margin-right:20px;margin-left:20px;margin-top: 70px;margin-bottom:20px">
         保存修改
         </a>
 </div>
+<script type="text/javascript">
+    $(function(){
+        var tmpl = '<li class="weui-uploader__file" style="background-image:url(#url#)"></li>',
+            $gallery = $("#gallery"), $galleryImg = $("#galleryImg"),
+            $uploaderInput = $("#uploaderInput"),
+            $uploaderFiles = $("#uploaderFiles")
+            ;
+
+        $uploaderInput.on("change", function(e){
+            var src, url = window.URL || window.webkitURL || window.mozURL, files = e.target.files;
+            for (var i = 0, len = files.length; i < len; ++i) {
+                var file = files[i];
+
+                if (url) {
+                    src = url.createObjectURL(file);
+                } else {
+                    src = e.target.result;
+                }
+
+                $uploaderFiles.append($(tmpl.replace('#url#', src)));
+            }
+        });
+        $uploaderFiles.on("click", "li", function(){
+            $galleryImg.attr("style", this.getAttribute("style"));
+            $gallery.fadeIn(100);
+        });
+        $gallery.on("click", function(){
+            $gallery.fadeOut(100);
+        });
+    });
+</script>

--- a/wechat/app/views/choseroute.html
+++ b/wechat/app/views/choseroute.html
@@ -11,7 +11,7 @@ router:#!/choseroute
         <article class="weui-article">
                 <section> 
                     <p>
-                        <img src="weui/src/example/images/trip5.png" alt="">
+                        <img src="weui/src/example/images/trip5.png" alt="" style="width:100%;display:block">
                     </p>
                 </section>
         </article>
@@ -89,7 +89,7 @@ router:#!/choseroute
         <article class="weui-article">
                 <section> 
                     <p>
-                        <img src="weui/src/example/images/trip2.png" alt="">
+                        <img src="weui/src/example/images/trip2.png" alt="" style="width:100%;display:block">
                     </p>
                    <font size="2">
                         全程无自费，点评过百，私人沙滩，两晚椰子岛，VILLA别墅，海豚岛，送大堡礁帝王岛。
@@ -101,7 +101,7 @@ router:#!/choseroute
         <article class="weui-article">
                 <section> 
                     <p>
-                        <img src="weui/src/example/images/trip3.png" alt="">
+                        <img src="weui/src/example/images/trip3.png" alt="" style="width:100%;display:block">
                     </p>
                     <font size="2">
                          包机直飞，升级2晚国五，赠京津交通，PP岛环岛游，帝王岛，攀牙湾泛舟，情人沙滩，人妖歌舞表演，骑大象观大象 

--- a/wechat/app/views/clsdetail.html
+++ b/wechat/app/views/clsdetail.html
@@ -10,7 +10,7 @@ router:#!/clsdetail
             <section>
                 <section>
                     <p>
-                        <img src="weui/src/example/images/trip6.png" alt="" style="margin-right:0px;margin-left:0px;margin-top: 1px">
+                        <img src="weui/src/example/images/trip6.png" alt="" style="width:100%;display:block;margin-right:0px;margin-left:0px;margin-top: 1px">
                     </p>
                 </section>
             </section>
@@ -117,7 +117,7 @@ router:#!/clsdetail
         </div>
         <div class="weui-flex__item">
             <div class="placeholder">
-                <a style="height:100%;width:100%;background-color:#ffa726" class="weui-btn weui-btn_mini weui-btn_default" ui-sref="clsorder">立即预定</a>
+                <a style="height:100%;width:100%;background-color:#ffa726" class="weui-btn weui-btn_mini weui-btn_default" ui-sref="hourse">立即预定</a>
             </div>
         </div>
     </div>

--- a/wechat/app/views/clsorder.html
+++ b/wechat/app/views/clsorder.html
@@ -26,29 +26,6 @@ router:#!/clsorder
             </div>
         </div>
          <div class="weui-cells">
-
-            <div class="weui-cell">
-                <div class="weui-cell__bd">
-                    <p>游客信息</p>
-                </div>
-                <div class="weui-cell__ft">常用游客</div>
-            </div>
-
-            <a class="weui-cell weui-cell_access" href="javascript:;">
-                <div class="weui-cell__bd">
-                    <p>游客1</p>
-                </div>
-                <div class="weui-cell__ft">
-                </div>
-            </a>
-            <a class="weui-cell weui-cell_access" href="javascript:;">
-                <div class="weui-cell__bd">
-                    <p>游客2</p>
-                </div>
-                <div class="weui-cell__ft">
-                </div>
-            </a>
-        </div>
         <label for="weuiAgree" class="weui-agree">
             <input id="weuiAgree" type="checkbox" class="weui-agree__checkbox">
             <span class="weui-agree__text">

--- a/wechat/app/views/hourse.html
+++ b/wechat/app/views/hourse.html
@@ -10,7 +10,7 @@ router:#!/hourse
             <section>
                 <section>
                     <p>
-                        <img src="weui/src/example/images/top1.png" alt="" style="margin-right:0px;margin-left:0px;margin-top: 1px">
+                        <img src="weui/src/example/images/top1.png" alt="" style="width:100%;display:block;margin-right:0px;margin-left:0px;margin-top: 1px">
                     </p>
                 </section>
             </section>
@@ -20,8 +20,25 @@ router:#!/hourse
 <div class="page" style="margin-left:15px;margin-right:15px">
     <div class="page__hd">
         <p class="page__desc">选择房间：</p>
+        <div class="weui-cells weui-cells_form">
+            <div class="weui-cell weui-cell_switch">
+                <div class="weui-cell__bd">是否公开订单</div>
+                <div class="weui-cell__ft">
+                    <label for="switchCP" class="weui-switch-cp">
+                        <input id="switchCP" class="weui-switch-cp__input" type="checkbox" checked="checked" />
+                        <div class="weui-switch-cp__box"></div>
+                    </label>
+                </div>
+            </div>
+        </div>
     </div>
-    <br>
+     <div class="weui-cell">
+                <div class="weui-cell__hd"><label for="" class="weui-label">订单截止时间</label></div>
+                <div class="weui-cell__bd">
+                    <input class="weui-input" type="datetime-local" value="" placeholder=""/>
+                </div>
+            </div>
+<hr>
 <div class="weui-flex">
     <div class="weui-flex__item" style="margin-right:20px;margin-left:10px">
         <div class="placeholder"> 
@@ -36,6 +53,11 @@ router:#!/hourse
                 </div>
              </div>
           </a>
+          <div class="weui-cell">
+                <div class="weui-cell__bd">
+                    <p>已支付</p>
+                </div>
+            </div>
         </div>
     </div>
     <div class="weui-flex__item" >
@@ -51,6 +73,11 @@ router:#!/hourse
                 </div>
           </div>
        </a>
+        <div class="weui-cell">
+                <div class="weui-cell__bd">
+                    <p>已支付</p>
+                </div>
+            </div>
       </div>
       </div>
 </div>
@@ -69,6 +96,11 @@ router:#!/hourse
                 </div>
              </div>
           </a>
+           <div class="weui-cell">
+                <div class="weui-cell__bd">
+                    <p>未支付</p>
+                </div>
+            </div>
         </div>
     </div>
     <div class="weui-flex__item">
@@ -85,6 +117,11 @@ router:#!/hourse
                 </div>
           </div>
        </a>
+       <div class="weui-cell">
+                <div class="weui-cell__bd">
+                    <p>未受邀</p>
+                </div>
+            </div>
       </div>
       </div>
 </div>
@@ -104,6 +141,11 @@ router:#!/hourse
                 </div>
              </div>
           </a>
+          <div class="weui-cell">
+                <div class="weui-cell__bd">
+                    <p>未受邀</p>
+                </div>
+            </div>
         </div>
     </div>
     <div class="weui-flex__item" >
@@ -120,10 +162,23 @@ router:#!/hourse
                 </div>
           </div>
        </a>
+       <div class="weui-cell">
+                <div class="weui-cell__bd">
+                    <p>未受邀</p>
+                </div>
+            </div>
       </div>
       </div>
 </div>
+<br>
 </div>
+<hr>
+        <label for="weuiAgree" class="weui-agree">
+            <input id="weuiAgree" type="checkbox" class="weui-agree__checkbox">
+            <span class="weui-agree__text">
+                我已阅读并接受<a href="javascript:void(0);">预定须知、合同、保险等条款</a>
+            </span>
+        </label>
 <div class="weui-btn-area">
             <a class="weui-btn weui-btn_primary" ui-sref="topay" id="showTooltips">去支付</a>
  </div>

--- a/wechat/app/views/ivdetail.html
+++ b/wechat/app/views/ivdetail.html
@@ -44,6 +44,7 @@ router:#!/ivdetail
 <br>
 <div class="weui-cells__title">选择房间</div>
 <br>
+<hr>
 <div class="weui-flex">
     <div class="weui-flex__item" style="margin-right:20px;margin-left:10px">
         <div class="placeholder"> 
@@ -58,11 +59,16 @@ router:#!/ivdetail
                 </div>
              </div>
           </a>
+          <div class="weui-cell">
+                <div class="weui-cell__bd">
+                    <p>已支付</p>
+                </div>
+            </div>
         </div>
     </div>
-    <div class="weui-flex__item" style="margin-right:20px;margin-left:20px">
+    <div class="weui-flex__item" >
       <div class="placeholder">
-       <a ui-sref="" class="weui-btn weui-btn_plain-default" style="width:160px">
+       <a ui-sref="" class="weui-btn weui-btn_plain-default" style="width:160px" style="margin-right:20px;margin-left:20px">
           <div class="weui-cell">
                 <div class="weui-cell__hd" style="position: relative;margin-right: 10px;">
                     <img src="weui/src/example/images/lhead2.png" style="width: 50px;display: block"/>
@@ -73,6 +79,11 @@ router:#!/ivdetail
                 </div>
           </div>
        </a>
+        <div class="weui-cell">
+                <div class="weui-cell__bd">
+                    <p>已支付</p>
+                </div>
+            </div>
       </div>
       </div>
 </div>
@@ -91,11 +102,16 @@ router:#!/ivdetail
                 </div>
              </div>
           </a>
+           <div class="weui-cell">
+                <div class="weui-cell__bd">
+                    <p>未支付</p>
+                </div>
+            </div>
         </div>
     </div>
-    <div class="weui-flex__item" style="margin-right:20px;margin-left:20px">
+    <div class="weui-flex__item">
       <div class="placeholder">
-       <a ui-sref="" class="weui-btn weui-btn_plain-default" style="width:160px">
+       <a ui-sref="" class="weui-btn weui-btn_plain-default" style="width:160px" style="margin-right:20px;margin-left:20px">
           <div class="weui-cell">
                 <div class="weui-cell__hd" style="position: relative;margin-right: 10px;">
                     <img src="weui/src/example/images/whitehead.png" style="width: 50px;display: block"/>
@@ -107,6 +123,11 @@ router:#!/ivdetail
                 </div>
           </div>
        </a>
+       <div class="weui-cell">
+                <div class="weui-cell__bd">
+                    <p>未受邀</p>
+                </div>
+            </div>
       </div>
       </div>
 </div>
@@ -126,13 +147,18 @@ router:#!/ivdetail
                 </div>
              </div>
           </a>
+          <div class="weui-cell">
+                <div class="weui-cell__bd">
+                    <p>未受邀</p>
+                </div>
+            </div>
         </div>
     </div>
-    <div class="weui-flex__item" style="margin-right:20px;margin-left:20px">
+    <div class="weui-flex__item" >
       <div class="placeholder">
        <a ui-sref="topay" class="weui-btn weui-btn_plain-default" style="width:160px">
           <div class="weui-cell">
-                <div class="weui-cell__hd" style="position: relative;margin-right: 10px;">
+                <div class="weui-cell__hd" style="position: relative" style="margin-right:20px;margin-left:20px">
                     <img src="weui/src/example/images/whitehead.png" style="width: 50px;display: block"/>
                     <span class="weui-badge" style="position: absolute;top: -.4em;right: -.4em;">可选</span>
                 </div>
@@ -142,12 +168,12 @@ router:#!/ivdetail
                 </div>
           </div>
        </a>
+       <div class="weui-cell">
+                <div class="weui-cell__bd">
+                    <p>未受邀</p>
+                </div>
+            </div>
       </div>
       </div>
 </div>
-<div class="page__bd page__bd_spacing">
-    <a ui-sref="topay" class="weui-btn weui-btn_primary" style="margin-right:20px;margin-left:20px;margin-top:40px;margin-bottom: 10px">
-       我要应邀
-        </a>
-</div>
-
+<br>

--- a/wechat/app/views/nofinish.html
+++ b/wechat/app/views/nofinish.html
@@ -39,7 +39,10 @@
                 </div>
             </div>
              <div class="weui-form-preview__ft">
-                 <font class="weui-form-preview__value" color="red">已支付</font>
-                <button type="submit" class="weui-form-preview__btn weui-form-preview__btn_primary" ui-sref="paydetail">查看支付详情</button>
             </div>
         </div>
+        <div class="weui-cells__title">生成分享链接</div>
+        <div class="weui-btn-area">
+            <a class="weui-btn weui-btn_primary" ui-sref="" id="showTooltips">分享</a>
+        </div>
+

--- a/wechat/app/views/orderls.html
+++ b/wechat/app/views/orderls.html
@@ -4,6 +4,96 @@ router:#!/orderls
  -->
 <div class="page">
     <div class="page__bd">
+    <div class="weui-form-preview">
+            <div class="weui-form-preview__hd">
+                <div class="weui-form-preview__item">
+                    <label class="weui-form-preview__label">邀约|未成行 </label>
+                </div>
+                <div class="weui-form-preview__item">
+                    <label class="weui-form-preview__label">订单号</label>
+                    <span class="weui-form-preview__value">432017020100078</span>
+                </div>
+            </div>
+            <div class="weui-form-preview__bd">
+                <div class="weui-form-preview__item">
+                    <label class="weui-form-preview__label">路线</label>
+                    <span class="weui-form-preview__value"><泰国-普吉岛-甲米6或7日游></span>
+                </div>
+                <div class="weui-form-preview__item">
+                    <label class="weui-form-preview__label">详情</label>
+                    <span class="weui-form-preview__value">天津往返直飞，入住泳池别墅，2晚国五酒店，无自费，畅游甲米，大堡礁浮潜，幻多奇主题乐园，预定赠送出海跟拍</span>
+                </div>
+                <div class="weui-form-preview__item">
+                    <label class="weui-form-preview__label">预定时间</label>
+                    <span class="weui-form-preview__value">2016-10-25</span>
+                </div>
+                <div class="weui-form-preview__item">
+                    <label class="weui-form-preview__label">出发时间</label>
+                    <span class="weui-form-preview__value">2016-11-05</span>
+                </div>
+                <div class="weui-form-preview__item">
+                    <label class="weui-form-preview__label">归来时间</label>
+                    <span class="weui-form-preview__value">2016-11-10</span>
+                </div>
+                <div class="weui-form-preview__item">
+                    <label class="weui-form-preview__label">出发城市</label>
+                    <span class="weui-form-preview__value">天津</span>
+                </div>
+                <div class="weui-form-preview__item">
+                    <label class="weui-form-preview__label">出游人数</label>
+                    <span class="weui-form-preview__value">6成人</span>
+                </div>
+            </div>
+              <div class="weui-form-preview__ft">
+                <button type="submit" class="weui-form-preview__btn weui-form-preview__btn_primary" ui-sref="nofinish">查看详细订单</button>
+             </div>
+        </div>
+        <br>
+         <div class="weui-form-preview">
+            <div class="weui-form-preview__hd">
+                <div class="weui-form-preview__item">
+                    <label class="weui-form-preview__label">应邀|已支付 </label>
+                </div>
+                <div class="weui-form-preview__item">
+                    <label class="weui-form-preview__label">订单号</label>
+                    <span class="weui-form-preview__value">432017011700023</span>
+                </div>
+            </div>
+            <div class="weui-form-preview__bd">
+                <div class="weui-form-preview__item">
+                    <label class="weui-form-preview__label">路线</label>
+                    <span class="weui-form-preview__value"><泰国-普吉岛-甲米6或7日游></span>
+                </div>
+                <div class="weui-form-preview__item">
+                    <label class="weui-form-preview__label">详情</label>
+                    <span class="weui-form-preview__value">天津往返直飞，入住泳池别墅，2晚国五酒店，无自费，畅游甲米，大堡礁浮潜，幻多奇主题乐园，预定赠送出海跟拍</span>
+                </div>
+                <div class="weui-form-preview__item">
+                    <label class="weui-form-preview__label">预定时间</label>
+                    <span class="weui-form-preview__value">2016-10-25</span>
+                </div>
+                <div class="weui-form-preview__item">
+                    <label class="weui-form-preview__label">出发时间</label>
+                    <span class="weui-form-preview__value">2016-11-05</span>
+                </div>
+                <div class="weui-form-preview__item">
+                    <label class="weui-form-preview__label">归来时间</label>
+                    <span class="weui-form-preview__value">2016-11-10</span>
+                </div>
+                <div class="weui-form-preview__item">
+                    <label class="weui-form-preview__label">出发城市</label>
+                    <span class="weui-form-preview__value">天津</span>
+                </div>
+                <div class="weui-form-preview__item">
+                    <label class="weui-form-preview__label">出游人数</label>
+                    <span class="weui-form-preview__value">6成人</span>
+                </div>
+            </div>
+              <div class="weui-form-preview__ft">
+                <button type="submit" class="weui-form-preview__btn weui-form-preview__btn_primary" ui-sref="paydetail">查看支付详情</button>
+            </div>
+        </div>
+        <br>
         <div class="weui-form-preview">
             <div class="weui-form-preview__hd">
                 <div class="weui-form-preview__item">
@@ -45,7 +135,6 @@ router:#!/orderls
                 </div>
             </div>
               <div class="weui-form-preview__ft">
-                <a class="weui-form-preview__btn weui-form-preview__btn_default" href="javascript:">已取消</a>
                 <button type="submit" class="weui-form-preview__btn weui-form-preview__btn_primary" ui-sref="paydetail">查看订单</button>
             </div>
         </div>
@@ -91,14 +180,14 @@ router:#!/orderls
                 </div>
             </div>
             <div class="weui-form-preview__ft">
-                <a class="weui-form-preview__btn weui-form-preview__btn_default" href="javascript:">已支付</a>
-                <button type="submit" class="weui-form-preview__btn weui-form-preview__btn_primary" ui-sref="evaluate">去评价</button>
+                <button type="submit" class="weui-form-preview__btn weui-form-preview__btn_primary" ui-sref="topay">去支付</button>
             </div>
         </div>
+        <br>
         <div class="weui-form-preview">
             <div class="weui-form-preview__hd">
                 <div class="weui-form-preview__item">
-                    <label class="weui-form-preview__label">应邀|未支付 </label>
+                    <label class="weui-form-preview__label">应邀|待评价 </label>
                 </div>
                 <div class="weui-form-preview__item">
                     <label class="weui-form-preview__label">订单号</label>
@@ -136,18 +225,18 @@ router:#!/orderls
                 </div>
             </div>
               <div class="weui-form-preview__ft">
-                <a class="weui-form-preview__btn weui-form-preview__btn_default" href="javascript:">待支付</a>
-                <button type="submit" class="weui-form-preview__btn weui-form-preview__btn_primary" ui-sref="topay">去支付</button>
+                <button type="submit" class="weui-form-preview__btn weui-form-preview__btn_primary" ui-sref="evaluate">去评价</button>
             </div>
         </div>
-        <div class="weui-form-preview">
+        <br>
+            <div class="weui-form-preview">
             <div class="weui-form-preview__hd">
                 <div class="weui-form-preview__item">
-                    <label class="weui-form-preview__label">邀约|未成行 </label>
+                    <label class="weui-form-preview__label">应邀|已成行 </label>
                 </div>
                 <div class="weui-form-preview__item">
                     <label class="weui-form-preview__label">订单号</label>
-                    <span class="weui-form-preview__value">432017020100078</span>
+                    <span class="weui-form-preview__value">432017011700023</span>
                 </div>
             </div>
             <div class="weui-form-preview__bd">
@@ -181,10 +270,10 @@ router:#!/orderls
                 </div>
             </div>
               <div class="weui-form-preview__ft">
-                <a class="weui-form-preview__btn weui-form-preview__btn_default" href="javascript:">已支付</a>
-                <button type="submit" class="weui-form-preview__btn weui-form-preview__btn_primary" ui-sref="paydetail">查看详细订单</button>
-             </div>
-    </div>
+                <button type="submit" class="weui-form-preview__btn weui-form-preview__btn_primary" ui-sref="">查看详情</button>
+            </div>
+        </div>
+        <br>
     <div class="weui-form-preview__ft">
     </div>
 </div>

--- a/wechat/app/views/paydetail.html
+++ b/wechat/app/views/paydetail.html
@@ -1,7 +1,7 @@
  <div class="weui-form-preview">
             <div class="weui-form-preview__hd">
                 <div class="weui-form-preview__item">
-                    <label class="weui-form-preview__label">跟团游|未成团 </label>
+                    <label class="weui-form-preview__label">未成行</label>
                 </div>
                 <div class="weui-form-preview__item">
                     <label class="weui-form-preview__label">订单号</label>
@@ -39,42 +39,136 @@
                 </div>
             </div>
         </div>
-    <div class="page">
-      <div class="page__bd">
-        <div class="weui-cells">
-            <div class="weui-cell">
-                <div class="weui-cell__bd">
-                    <p>邀约人：张小二</p>
-                    <p>支付金额：￥50,000.00</p>
-                </div>
-                <div class="weui-cell__ft">状态：已支付</div>
-            </div>
-            <div class="weui-cell">
-                <div class="weui-cell__bd">
-                    <p>受约人：张二</p>
-                    <p>支付金额：￥0.01</p>
-                </div>
-                <div class="weui-cell__ft">状态：已支付</div>
-            </div>
-            <div class="weui-cell">
-                <div class="weui-cell__bd">
-                    <p>受约人：李四</p>
-                    <p>支付金额：￥0.01</p>
-                </div>
-                <div class="weui-cell__ft">状态：已支付</div>
-            </div>
-            <div class="weui-cell">
-                <div class="weui-cell__bd">
-                    <p>受约人：王五</p>
-                    <p>支付金额：￥10,000.00</p>
-                </div>
-                <div class="weui-cell__ft">状态：已支付</div>
-            </div>
+        <hr>
+    <div class="weui-flex">
+    <div class="weui-flex__item" style="margin-right:20px;margin-left:10px">
+        <div class="placeholder"> 
+         <a ui-sref="" class="weui-btn weui-btn_plain-default" style="width:160px"> 
              <div class="weui-cell">
-             <div class="weui-cell__bd">
+                <div class="weui-cell__hd" style="position: relative;margin-right: 10px;">
+                    <img src="weui/src/example/images/lhead1.png" style="width: 50px;display: block"/>
                 </div>
-                <div class="weui-cell__ft"><font color="red">剩余名额：2人</font></div>
+                <div class="weui-cell__bd">
+                    <p>♀</p>
+                    <p style="font-size: 13px;color: #888888;">￥5,0000.00</p>
+                </div>
+             </div>
+          </a>
+          <div class="weui-cell">
+                <div class="weui-cell__bd">
+                    <p>已支付</p>
+                </div>
             </div>
         </div>
-      </div>
     </div>
+    <div class="weui-flex__item" >
+      <div class="placeholder">
+       <a ui-sref="" class="weui-btn weui-btn_plain-default" style="width:160px" style="margin-right:20px;margin-left:20px">
+          <div class="weui-cell">
+                <div class="weui-cell__hd" style="position: relative;margin-right: 10px;">
+                    <img src="weui/src/example/images/lhead2.png" style="width: 50px;display: block"/>
+                </div>
+                <div class="weui-cell__bd">
+                    <p>♀</p>
+                    <p style="font-size: 13px;color: #888888;">￥0.01</p>
+                </div>
+          </div>
+       </a>
+        <div class="weui-cell">
+                <div class="weui-cell__bd">
+                    <p>已支付</p>
+                </div>
+            </div>
+      </div>
+      </div>
+</div>
+<hr>
+<div class="weui-flex">
+    <div class="weui-flex__item" style="margin-right:20px;margin-left:10px">
+        <div class="placeholder"> 
+         <a ui-sref="" class="weui-btn weui-btn_plain-default" style="width:160px"> 
+             <div class="weui-cell">
+                <div class="weui-cell__hd" style="position: relative;margin-right: 10px;">
+                    <img src="weui/src/example/images/lhead5.png" style="width: 50px;display: block"/>
+                </div>
+                <div class="weui-cell__bd">
+                    <p>♂</p>
+                    <p style="font-size: 13px;color: #888888;">￥0.01</p>
+                </div>
+             </div>
+          </a>
+           <div class="weui-cell">
+                <div class="weui-cell__bd">
+                    <p>未支付</p>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="weui-flex__item">
+      <div class="placeholder">
+       <a ui-sref="" class="weui-btn weui-btn_plain-default" style="width:160px" style="margin-right:20px;margin-left:20px">
+          <div class="weui-cell">
+                <div class="weui-cell__hd" style="position: relative;margin-right: 10px;">
+                    <img src="weui/src/example/images/whitehead.png" style="width: 50px;display: block"/>
+                    <span class="weui-badge" style="position: absolute;top: -.4em;right: -.4em;"></span>
+                </div>
+                <div class="weui-cell__bd">
+                    <p>♂</p>
+                    <p style="font-size: 13px;color: #888888;">￥0.01</p>
+                </div>
+          </div>
+       </a>
+       <div class="weui-cell">
+                <div class="weui-cell__bd">
+                    <p>未受邀</p>
+                </div>
+            </div>
+      </div>
+      </div>
+</div>
+<hr>
+<div class="weui-flex">
+    <div class="weui-flex__item" style="margin-right:20px;margin-left:10px">
+        <div class="placeholder"> 
+         <a ui-sref="topay" class="weui-btn weui-btn_plain-default" style="width:160px"> 
+             <div class="weui-cell">
+                <div class="weui-cell__hd" style="position: relative;margin-right: 10px;">
+                    <img src="weui/src/example/images/whitehead.png" style="width: 50px;display: block"/>
+                    <span class="weui-badge" style="position: absolute;top: -.4em;right: -.4em;">可选</span>
+                </div>
+                <div class="weui-cell__bd">
+                    <p>♀</p>
+                    <p style="font-size: 13px;color: #888888;">￥10,000.00</p>
+                </div>
+             </div>
+          </a>
+          <div class="weui-cell">
+                <div class="weui-cell__bd">
+                    <p>未受邀</p>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="weui-flex__item" >
+      <div class="placeholder">
+       <a ui-sref="topay" class="weui-btn weui-btn_plain-default" style="width:160px">
+          <div class="weui-cell">
+                <div class="weui-cell__hd" style="position: relative" style="margin-right:20px;margin-left:20px">
+                    <img src="weui/src/example/images/whitehead.png" style="width: 50px;display: block"/>
+                    <span class="weui-badge" style="position: absolute;top: -.4em;right: -.4em;">可选</span>
+                </div>
+                <div class="weui-cell__bd">
+                    <p>♀</p>
+                    <p style="font-size: 13px;color: #888888;">￥0.01</p>
+                </div>
+          </div>
+       </a>
+       <div class="weui-cell">
+                <div class="weui-cell__bd">
+                    <p>未受邀</p>
+                </div>
+            </div>
+      </div>
+      </div>
+</div>
+<br>

--- a/wechat/app/views/paysuccess.html
+++ b/wechat/app/views/paysuccess.html
@@ -22,7 +22,9 @@ router:#!/paysuccess
             <article class="weui-article">
                 <section>
                     <p>
-                        <img src="weui/src/example/images/trip1.png" alt="">
+                    <a ui-sref="clsdetail">
+                        <img src="weui/src/example/images/trip1.png" alt="" style="width:100%;display:block">
+                    </a>
                     </p>
                     <p>
                         全程无自费，点评过百，私人沙滩，两晚椰子岛，VILLA别墅，海豚岛，送大堡礁帝王岛。

--- a/wechat/app/views/personal.html
+++ b/wechat/app/views/personal.html
@@ -43,13 +43,6 @@ router:#!/personal
         <div class="weui-cell__ft">
         </div>
     </a>
-    <a class="weui-cell weui-cell_access" ui-sref="touristls">
-        <div class="weui-cell__bd">
-            <p>常用游客</p>
-        </div>
-        <div class="weui-cell__ft">
-        </div>
-    </a>
 </div>
 <br>
 <div class="weui-cells">
@@ -60,8 +53,10 @@ router:#!/personal
         <div class="page__bd">
             <article class="weui-article">
                 <section>
-                    <p>
-                        <img src="weui/src/example/images/trip1.png" alt="">
+                    <p> 
+                    <a ui-sref="clsdetail">
+                        <img src="weui/src/example/images/trip1.png" alt="" style="width:100%;display:block">
+                    </a>
                     </p>
                     <p>
                         全程无自费，点评过百，私人沙滩，两晚椰子岛，VILLA别墅，海豚岛，送大堡礁帝王岛。
@@ -76,7 +71,9 @@ router:#!/personal
             <article class="weui-article">
                 <section>
                     <p>
-                        <img src="weui/src/example/images/trip1.png" alt="">
+                    <a ui-sref="clsdetail">
+                        <img src="weui/src/example/images/trip1.png" alt="" style="width:100%;display:block">
+                    </a>
                     </p>
                     <p>
                         全程无自费，点评过百，私人沙滩，两晚椰子岛，VILLA别墅，海豚岛，送大堡礁帝王岛。
@@ -91,7 +88,9 @@ router:#!/personal
             <article class="weui-article">
                 <section>
                     <p>
-                        <img src="weui/src/example/images/trip1.png" alt="">
+                    <a ui-sref="clsdetail">
+                        <img src="weui/src/example/images/trip1.png" alt="" style="width:100%;display:block">
+                    </a>
                     </p>
                     <p>
                         全程无自费，点评过百，私人沙滩，两晚椰子岛，VILLA别墅，海豚岛，送大堡礁帝王岛。

--- a/wechat/app/views/routes.html
+++ b/wechat/app/views/routes.html
@@ -57,7 +57,7 @@ router:#!/routes
                   </div>
             <div class="weui-form-preview__ft">
                 <a class="weui-form-preview__btn weui-form-preview__btn_default" href="javascript:">收藏</a>
-                <button type="submit" class="weui-form-preview__btn weui-form-preview__btn_primary" ui-sref="clsdetail">查看详情</button>
+                <button type="submit" class="weui-form-preview__btn weui-form-preview__btn_primary" ui-sref="clsdetail">立即预定</button>
             </div>
       
     </div>
@@ -119,7 +119,7 @@ router:#!/routes
                   </div>
             <div class="weui-form-preview__ft">
                 <a class="weui-form-preview__btn weui-form-preview__btn_default" href="javascript:">收藏</a>
-                <button type="submit" class="weui-form-preview__btn weui-form-preview__btn_primary" ui-sref="clsdetail">查看详情</button>
+                <button type="submit" class="weui-form-preview__btn weui-form-preview__btn_primary" ui-sref="clsdetail">立即预定</button>
             </div>
       
     </div>

--- a/wechat/app/views/toinvite.html
+++ b/wechat/app/views/toinvite.html
@@ -10,7 +10,7 @@ router:#!/toinvite
             <section>
                 <section>
                     <p>
-                        <img src="weui/src/example/images/top1.png" alt="" style="margin-right:0px;margin-left:0px;margin-top: 1px">
+                        <img src="weui/src/example/images/top1.png" alt="" style="width:100%;display:block;margin-right:0px;margin-left:0px;margin-top: 1px">
                     </p>
                 </section>
             </section>


### PR DESCRIPTION
1.去掉页面中与游客相关的部分
2.去掉签证部分
3.去掉clsdetail页面的相关跳转
4.routes页改回立即预定
5.个人中心的个人信息项按照E-R图进行补充
（1）性别（慎重，一旦填写不可修改）
（2）地区
（3）昵称
（4）出生日期（慎重，一旦填写不可修改）
（5）上传头像
（6）绑定身份证
         上传身份证正反面照片
6.选择房间页面添加
（1）是否公开邀约选项
（2）阅读条款
（3）设置截止时间
（4）每个床位下添加已支付未支付的状态信息
（5）将应邀和邀约页面的选择床位改为不同的样式：发布邀约有去支付按钮；应邀没有我要应邀按钮，改为直接点击可选床位跳转入支付页面。
7.调整订单状态设置
未支付、未成行、未评价、最终态
8.在订单页添加分享按钮，修改支付状态list为选择房间的样式
9.随便逛逛组件：点击图片或图片下面的价格跳转到clsdetail页面
10元素改为适应屏幕大小